### PR TITLE
Fix unpinned Docker dependency in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /home/jovyan/work
 COPY --chown=${NB_UID}:${NB_GID} . /home/jovyan/work
 
 # Install extra packages not already in the base image
-RUN pip install --no-cache-dir shap
+RUN pip install --no-cache-dir shap==0.49.1
 
 EXPOSE 8888
 


### PR DESCRIPTION
This PR addresses milestone 1 feedback about unpinned Docker dependencies.

Changes made:
- pinned SHAP in the Dockerfile to version 0.49.1

This makes the Docker setup more reproducible.